### PR TITLE
FIN-26: load default product dynamically, memoize selected curve, inc…

### DIFF
--- a/src/components/MainChart.tsx
+++ b/src/components/MainChart.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useMemo, useState} from 'react';
 import {Line} from 'react-chartjs-2';
 
 import {
@@ -44,7 +44,7 @@ const MainChart = () => {
 
   useEffect(() => {
     const fetchHistoricalData = async () => {
-      if (endDate) {
+      if (endDate && selectedProduct.id) {
         const data = await getHistoricalPrices(selectedProduct.id, startDate, endDate);
         setHistoricalData(data);
       }
@@ -74,18 +74,19 @@ const MainChart = () => {
     }
   };
 
-  const chartData = {
-    // labels,
-    datasets: [
-      {
-        tension: 0.3,
-        label: datasets.length ? `${selectedProduct.label} - ${selectedMetric}` : 'No data',
-        data: datasets,
-        borderColor: 'rgb(255, 99, 132)',
-        backgroundColor: 'rgba(200, 99, 132, 0.5)',
-      },
-    ],
-  };
+  const chartData = useMemo(() => {
+    return {
+      datasets: [
+        {
+          tension: 0.3,
+          label: datasets.length ? `${selectedProduct.label} - ${selectedMetric}` : 'No data',
+          data: datasets,
+          borderColor: 'rgb(255, 99, 132)',
+          backgroundColor: 'rgba(200, 99, 132, 0.5)',
+        },
+      ],
+    };
+  }, [historicalData]);
 
   return (
     <>

--- a/src/components/ProductNameInput.tsx
+++ b/src/components/ProductNameInput.tsx
@@ -30,6 +30,9 @@ const ProductNameInput = () => {
       }
     );
     setCatalogProducts(products);
+    if (!selectedProduct.id) {
+      setSelectedProduct(products[0]);
+    }
   };
 
   const handleProductChange = (
@@ -45,6 +48,12 @@ const ProductNameInput = () => {
     setSelectedProduct(selectedProduct);
   };
 
+  const handleProductSearch = (e: {target: {value: string}}) => {
+    if (e.target.value.length >= 2) {
+      fetchCatalogData(e.target.value);
+    }
+  };
+
   return (
     <>
       <Grid item>
@@ -57,9 +66,9 @@ const ProductNameInput = () => {
           renderInput={(params) => (
             <TextField
               {...params}
-              label='Product'
+              label='Search Product'
               size='small'
-              onChange={(e) => fetchCatalogData(e.target.value)}
+              onChange={handleProductSearch}
               placeholder={'Search by Symbol'}
             />
           )}

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -5,10 +5,10 @@ export const startDateAtom = atom(subMonths(new Date(), 3));
 export const endDateAtom = atom(new Date());
 export const productOptionsAtom = atom([]);
 export const selectedProductAtom = atom({
-  id: 'AAPL',
-  label: 'Kurv Yield Premium Strategy Apple (AAPL) ETF',
-  currency: 'USD',
-  stockExchange: 'Cboe US',
+  id: '',
+  label: '',
+  currency: '',
+  stockExchange: '',
 });
 export const selectedMetricAtom = atom('close');
 export const historicalDataAtom = atom({


### PR DESCRIPTION
Get the first product to initialize chart data
Prevent chart from self-refreshing before new data is loaded
Increase minimum search string length to two, as number of API call per day is limited